### PR TITLE
Add last activity timestamp to worktree listing

### DIFF
--- a/crates/arbor-core/src/worktree.rs
+++ b/crates/arbor-core/src/worktree.rs
@@ -1,7 +1,9 @@
 use {
     std::{
+        fs,
         path::{Path, PathBuf},
         process::{Command, Output},
+        time::SystemTime,
     },
     thiserror::Error,
 };
@@ -263,6 +265,57 @@ pub fn canonicalize_if_possible(path: PathBuf) -> PathBuf {
         Ok(canonical) => canonical,
         Err(_) => path,
     }
+}
+
+/// Resolves the actual `.git` directory for a worktree path.
+///
+/// For the main worktree this is simply `<path>/.git`.  For linked worktrees
+/// the `.git` entry is a file containing `gitdir: <path>` pointing to a
+/// directory inside the main repo's `.git/worktrees/` folder.
+pub fn resolve_git_dir(worktree_path: &Path) -> Option<PathBuf> {
+    let dot_git = worktree_path.join(".git");
+    if dot_git.is_dir() {
+        return Some(dot_git);
+    }
+    if dot_git.is_file() {
+        let content = fs::read_to_string(&dot_git).ok()?;
+        let gitdir = content.strip_prefix("gitdir: ")?.trim();
+        let gitdir_path = PathBuf::from(gitdir);
+        let resolved = if gitdir_path.is_relative() {
+            worktree_path.join(gitdir_path)
+        } else {
+            gitdir_path
+        };
+        if resolved.is_dir() {
+            return Some(resolved);
+        }
+    }
+    None
+}
+
+/// Returns the most recent modification time (as unix milliseconds) among
+/// key git bookkeeping files: `index`, `logs/HEAD`, and `HEAD`.
+///
+/// This covers essentially all git write operations (commits, staging,
+/// checkouts, rebases, merges, etc.) without spawning any processes.
+pub fn last_git_activity_ms(worktree_path: &Path) -> Option<u64> {
+    let git_dir = resolve_git_dir(worktree_path)?;
+    let candidates = [
+        git_dir.join("index"),
+        git_dir.join("logs").join("HEAD"),
+        git_dir.join("HEAD"),
+    ];
+
+    candidates
+        .iter()
+        .filter_map(|path| fs::metadata(path).ok()?.modified().ok())
+        .filter_map(|mtime| {
+            mtime
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_millis() as u64)
+        })
+        .max()
 }
 
 #[cfg(test)]

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -159,6 +159,7 @@ struct WorktreeSummary {
     pr_url: Option<String>,
     diff_summary: Option<changes::DiffLineSummary>,
     agent_state: Option<AgentState>,
+    last_activity_unix_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -1787,6 +1788,15 @@ impl ArborWindow {
                     .map(|state| (worktree.path.clone(), state))
             })
             .collect();
+        let previous_activity: HashMap<PathBuf, u64> = self
+            .worktrees
+            .iter()
+            .filter_map(|worktree| {
+                worktree
+                    .last_activity_unix_ms
+                    .map(|ts| (worktree.path.clone(), ts))
+            })
+            .collect();
 
         let mut refresh_errors = Vec::new();
         let mut next_worktrees = Vec::new();
@@ -1811,6 +1821,13 @@ impl ArborWindow {
             worktree.pr_number = previous_pr_numbers.get(&worktree.path).copied();
             worktree.pr_url = previous_pr_urls.get(&worktree.path).cloned();
             worktree.agent_state = previous_agent_states.get(&worktree.path).copied();
+            // Take the max of fresh git-based timestamp and previous value
+            // (which may include agent activity).
+            let prev = previous_activity.get(&worktree.path).copied();
+            worktree.last_activity_unix_ms = match (worktree.last_activity_unix_ms, prev) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (a, b) => a.or(b),
+            };
         }
 
         let rows_changed = worktree_rows_changed(&self.worktrees, &next_worktrees);
@@ -5702,6 +5719,17 @@ impl ArborWindow {
                                                                         );
                                                                 }
 
+                                                                if let Some(activity_ms) = worktree.last_activity_unix_ms {
+                                                                    details = details.child(
+                                                                        div()
+                                                                            .text_xs()
+                                                                            .text_color(rgb(
+                                                                                theme.text_disabled,
+                                                                            ))
+                                                                            .child(format_relative_time(activity_ms)),
+                                                                    );
+                                                                }
+
                                                                 details
                                                             }),
                                                     )
@@ -7726,6 +7754,8 @@ impl WorktreeSummary {
             .unwrap_or_else(|| "-".to_owned());
         let is_primary_checkout = entry.path.as_path() == repo_root;
 
+        let last_activity_unix_ms = worktree::last_git_activity_ms(&entry.path);
+
         Self {
             repo_root: repo_root.to_path_buf(),
             path: entry.path.clone(),
@@ -7736,6 +7766,7 @@ impl WorktreeSummary {
             pr_url: None,
             diff_summary: None,
             agent_state: None,
+            last_activity_unix_ms,
         }
     }
 }
@@ -7882,7 +7913,7 @@ fn process_agent_ws_message(
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
-            let entries: Vec<(String, AgentState)> = sessions
+            let entries: Vec<(String, AgentState, Option<u64>)> = sessions
                 .iter()
                 .filter_map(|s| {
                     let cwd = s.get("cwd")?.as_str()?;
@@ -7892,7 +7923,8 @@ fn process_agent_ws_message(
                         "waiting" => AgentState::Waiting,
                         _ => return None,
                     };
-                    Some((cwd.to_owned(), state))
+                    let updated_at = s.get("updated_at_unix_ms").and_then(|v| v.as_u64());
+                    Some((cwd.to_owned(), state, updated_at))
                 })
                 .collect();
             let _ = this.update(cx, |this, cx| {
@@ -7910,7 +7942,9 @@ fn process_agent_ws_message(
                         "waiting" => AgentState::Waiting,
                         _ => return,
                     };
-                    let entries = vec![(cwd.to_owned(), state)];
+                    let updated_at =
+                        session.get("updated_at_unix_ms").and_then(|v| v.as_u64());
+                    let entries = vec![(cwd.to_owned(), state, updated_at)];
                     let _ = this.update(cx, |this, cx| {
                         apply_agent_ws_update(this, &entries);
                         cx.notify();
@@ -7922,7 +7956,7 @@ fn process_agent_ws_message(
     }
 }
 
-fn apply_agent_ws_snapshot(app: &mut ArborWindow, entries: &[(String, AgentState)]) {
+fn apply_agent_ws_snapshot(app: &mut ArborWindow, entries: &[(String, AgentState, Option<u64>)]) {
     tracing::debug!(count = entries.len(), "agent WS snapshot received");
     for worktree in &mut app.worktrees {
         worktree.agent_state = None;
@@ -7930,10 +7964,10 @@ fn apply_agent_ws_snapshot(app: &mut ArborWindow, entries: &[(String, AgentState
     apply_agent_ws_update(app, entries);
 }
 
-fn apply_agent_ws_update(app: &mut ArborWindow, entries: &[(String, AgentState)]) {
+fn apply_agent_ws_update(app: &mut ArborWindow, entries: &[(String, AgentState, Option<u64>)]) {
     let worktree_paths: Vec<PathBuf> = app.worktrees.iter().map(|w| w.path.clone()).collect();
 
-    for (cwd, state) in entries {
+    for (cwd, state, updated_at) in entries {
         let cwd_path = Path::new(cwd);
         // Find the most specific (longest) worktree path that is a prefix of this cwd,
         // same logic as worktrees_with_agents().
@@ -7955,6 +7989,11 @@ fn apply_agent_ws_update(app: &mut ArborWindow, entries: &[(String, AgentState)]
                     "agent activity matched"
                 );
                 worktree.agent_state = Some(*state);
+                if let Some(ts) = updated_at {
+                    worktree.last_activity_unix_ms = Some(
+                        worktree.last_activity_unix_ms.unwrap_or(0).max(*ts),
+                    );
+                }
             }
         }
     }
@@ -8037,6 +8076,29 @@ fn worktree_rows_changed(previous: &[WorktreeSummary], next: &[WorktreeSummary])
             || left.branch != right.branch
             || left.is_primary_checkout != right.is_primary_checkout
     })
+}
+
+fn format_relative_time(unix_ms: u64) -> String {
+    let now_ms = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let age_secs = now_ms.saturating_sub(unix_ms) / 1000;
+
+    if age_secs < 60 {
+        return "just now".to_owned();
+    }
+    let minutes = age_secs / 60;
+    if minutes < 60 {
+        return format!("{minutes}m ago");
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+    let days = hours / 24;
+    format!("{days}d ago")
 }
 
 fn terminal_tab_title(session: &TerminalSession) -> String {

--- a/crates/arbor-httpd/src/main.rs
+++ b/crates/arbor-httpd/src/main.rs
@@ -99,6 +99,7 @@ struct WorktreeDto {
     path: String,
     branch: String,
     is_primary_checkout: bool,
+    last_activity_unix_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -281,6 +282,8 @@ async fn list_worktrees(
         match worktree::list(&repository_root) {
             Ok(entries) => {
                 for entry in entries {
+                    let last_activity_unix_ms =
+                        worktree::last_git_activity_ms(&entry.path);
                     worktrees.push(WorktreeDto {
                         repo_root: repository_root.display().to_string(),
                         path: entry.path.display().to_string(),
@@ -290,6 +293,7 @@ async fn list_worktrees(
                             .map(short_branch)
                             .unwrap_or_else(|| "-".to_owned()),
                         is_primary_checkout: entry.path.as_path() == repository_root,
+                        last_activity_unix_ms,
                     });
                 }
             },

--- a/crates/arbor-web-ui/app/src/main.ts
+++ b/crates/arbor-web-ui/app/src/main.ts
@@ -10,6 +10,7 @@ type Worktree = {
   path: string;
   branch: string;
   is_primary_checkout: boolean;
+  last_activity_unix_ms: number | null;
 };
 
 type TerminalState = "running" | "completed" | "failed";
@@ -150,7 +151,8 @@ function parseWorktrees(value: unknown): Worktree[] {
       repo_root: repoRoot,
       path,
       branch,
-      is_primary_checkout: isPrimaryCheckout
+      is_primary_checkout: isPrimaryCheckout,
+      last_activity_unix_ms: readNumber(item["last_activity_unix_ms"])
     });
   }
 
@@ -688,10 +690,13 @@ function renderWorktreesPanel(): HTMLElement {
     });
 
     const label = createElement("span", "list-label", worktree.path);
+    const activity = worktree.last_activity_unix_ms !== null
+      ? ` · ${formatSessionAge(worktree.last_activity_unix_ms)}`
+      : "";
     const meta = createElement(
       "span",
       "list-meta",
-      `${worktree.branch}${worktree.is_primary_checkout ? " (primary)" : ""}`
+      `${worktree.branch}${worktree.is_primary_checkout ? " (primary)" : ""}${activity}`
     );
     button.append(label, meta);
     item.append(button);


### PR DESCRIPTION
## Summary

- Add relative time display (e.g. "just now", "3m ago", "2h ago", "5d ago") to each worktree in the sidebar, HTTP API, and web UI
- Detect git activity via filesystem mtime of `index`, `logs/HEAD`, and `HEAD` files — no process spawning needed
- Merge agent WebSocket `updated_at_unix_ms` timestamps so any Claude/Codex interaction also updates the activity time
- Handle linked worktrees by resolving `.git` gitdir pointer files

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test -p arbor-core` — all 23 tests pass
- [ ] Run the app, verify worktree listing shows relative times
- [ ] Make a git commit in a worktree, verify the time updates on next refresh
- [ ] Have Claude running in a worktree, verify agent activity updates the timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)