### PR TITLE
Add sound for task completion notifications

### DIFF
--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -1377,9 +1377,9 @@ impl ArborWindow {
             .map(|worktree| worktree.path.clone())
     }
 
-    fn maybe_notify(&self, title: &str, body: &str) {
+    fn maybe_notify(&self, title: &str, body: &str, play_sound: bool) {
         if self.notifications_enabled && !self.window_is_active {
-            notifications::send(title, body);
+            notifications::send(title, body, play_sound);
         }
     }
 
@@ -1391,7 +1391,7 @@ impl ArborWindow {
             terminal_grid_size_from_scroll_handle(&self.terminal_scroll_handle, cx);
         let daemon = self.terminal_daemon.clone();
         let mut sessions_to_close = Vec::new();
-        let mut pending_notifications: Vec<(String, String)> = Vec::new();
+        let mut pending_notifications: Vec<(String, String, bool)> = Vec::new();
 
         for index in 0..self.terminals.len() {
             let Some(runtime) = self
@@ -1443,6 +1443,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "Terminal completed".to_owned(),
                                 format!("`{}` completed successfully", session.title),
+                                true,
                             ));
                             sessions_to_close.push(session.id);
                         } else {
@@ -1452,6 +1453,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "Terminal failed".to_owned(),
                                 format!("`{}` failed with code {exit_code}", session.title),
+                                false,
                             ));
                             self.notice = Some(format!(
                                 "terminal tab `{}` exited with code {exit_code}",
@@ -1528,6 +1530,7 @@ impl ArborWindow {
                                     pending_notifications.push((
                                         "Terminal completed".to_owned(),
                                         format!("`{title}` completed successfully"),
+                                        true,
                                     ));
                                     sessions_to_close.push(session.id);
                                 } else if session.state == TerminalState::Failed {
@@ -1536,6 +1539,7 @@ impl ArborWindow {
                                     pending_notifications.push((
                                         "Terminal failed".to_owned(),
                                         format!("`{title}` failed with code {exit_code}"),
+                                        false,
                                     ));
                                     self.notice = Some(format!(
                                         "terminal tab `{title}` exited with code {exit_code}",
@@ -1675,6 +1679,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "SSH terminal completed".to_owned(),
                                 format!("`{}` completed successfully", session.title),
+                                true,
                             ));
                             sessions_to_close.push(session.id);
                         } else {
@@ -1684,6 +1689,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "SSH terminal failed".to_owned(),
                                 format!("`{}` failed with code {exit_code}", session.title),
+                                false,
                             ));
                             self.notice = Some(format!(
                                 "SSH terminal tab `{}` exited with code {exit_code}",
@@ -1732,6 +1738,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "Mosh terminal completed".to_owned(),
                                 format!("`{}` completed successfully", session.title),
+                                true,
                             ));
                             sessions_to_close.push(session.id);
                         } else {
@@ -1741,6 +1748,7 @@ impl ArborWindow {
                             pending_notifications.push((
                                 "Mosh terminal failed".to_owned(),
                                 format!("`{}` failed with code {exit_code}", session.title),
+                                false,
                             ));
                             self.notice = Some(format!(
                                 "mosh terminal tab `{}` exited with code {exit_code}",
@@ -1752,8 +1760,8 @@ impl ArborWindow {
             };
         }
 
-        for (title, body) in pending_notifications {
-            self.maybe_notify(&title, &body);
+        for (title, body, play_sound) in pending_notifications {
+            self.maybe_notify(&title, &body, play_sound);
         }
 
         for session_id in sessions_to_close {

--- a/crates/arbor-gui/src/notifications.rs
+++ b/crates/arbor-gui/src/notifications.rs
@@ -1,9 +1,11 @@
-pub fn send(title: &str, body: &str) {
-    if let Err(error) = notify_rust::Notification::new()
-        .summary(title)
-        .body(body)
-        .show()
-    {
+pub fn send(title: &str, body: &str, play_sound: bool) {
+    let mut notification = notify_rust::Notification::new();
+    notification.summary(title).body(body);
+    if play_sound {
+        notification.sound_name("default");
+    }
+
+    if let Err(error) = notification.show() {
         tracing::warn!(%error, "failed to send desktop notification");
     }
 }


### PR DESCRIPTION
## Summary
- add optional sound support to desktop notifications in the GUI notification helper
- play the default system sound for terminal/task completion notifications
- keep failure notifications silent while preserving existing notification behavior

## Validation
- just format
- cargo +nightly-2025-11-30 clippy --all --benches --tests --examples --all-features