### PR TITLE
Open repository GitHub links from sidebar icons

### DIFF
--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -53,6 +53,9 @@ use {
 
 const FONT_UI: &str = ".ZedSans";
 const FONT_MONO: &str = "CaskaydiaMono Nerd Font Mono";
+#[cfg(target_os = "macos")]
+const TERMINAL_FONT_FAMILIES: [&str; 5] = [FONT_MONO, "SF Mono", "Menlo", "Monaco", "Courier New"];
+#[cfg(not(target_os = "macos"))]
 const TERMINAL_FONT_FAMILIES: [&str; 6] = [
     FONT_MONO,
     ".ZedMono",


### PR DESCRIPTION
## Summary
- make repository avatar/GitHub icon clicks in the left pane open the repository GitHub URL in the browser
- apply the behavior in both expanded and collapsed sidebar modes
- stop click propagation on icon clicks so repository-row selection behavior is unchanged
- avoid probing .ZedMono on macOS to prevent CoreText fallback warnings at startup

## Validation
- just format
- just lint