### PR TITLE
docs: add Linux options to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,6 +24,11 @@ body:
         - macOS 15 (Sequoia)
         - macOS 14 (Sonoma)
         - macOS 13 (Ventura)
+        - Linux (Arch/Manjaro)
+        - Linux (Ubuntu/Debian)
+        - Linux (Fedora/RHEL)
+        - Linux (NixOS)
+        - Linux (Other)
         - Other (specify below)
     validations:
       required: true
@@ -41,7 +46,8 @@ body:
       label: Architecture
       options:
         - Apple Silicon (M1/M2/M3/M4)
-        - Intel x86_64
+        - x86_64 (Intel/AMD)
+        - aarch64 (ARM64)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -24,6 +24,11 @@ body:
         - macOS 15 (Sequoia)
         - macOS 14 (Sonoma)
         - macOS 13 (Ventura)
+        - Linux (Arch/Manjaro)
+        - Linux (Ubuntu/Debian)
+        - Linux (Fedora/RHEL)
+        - Linux (NixOS)
+        - Linux (Other)
         - Other (specify below)
     validations:
       required: true
@@ -41,7 +46,8 @@ body:
       label: Architecture
       options:
         - Apple Silicon (M1/M2/M3/M4)
-        - Intel x86_64
+        - x86_64 (Intel/AMD)
+        - aarch64 (ARM64)
     validations:
       required: true
 


### PR DESCRIPTION
The OS dropdown only had macOS options. Added:
- Linux (Arch/Manjaro)
- Linux (Ubuntu/Debian)
- Linux (Fedora/RHEL)
- Linux (NixOS)
- Linux (Other)

Also updated Architecture dropdown:
- Apple Silicon (M1/M2/M3/M4)
- x86_64 (Intel/AMD)
- aarch64 (ARM64)