### PR TITLE
fix(gui): use consistent icon slot size for agent preset tabs

### DIFF
--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -19884,7 +19884,8 @@ fn agent_preset_button_content(kind: AgentPresetKind, text_color: u32) -> Div {
     log_preset_icon_render_once(kind);
     let icon = preset_icon_image(kind);
     let icon_size = preset_icon_render_size_px(kind);
-    let icon_slot_size = icon_size.max(14.);
+    // Use consistent slot size for all icons to ensure vertical alignment
+    let icon_slot_size = 20_f32;
     let fallback_color = match kind {
         AgentPresetKind::Claude => 0xD97757,
         AgentPresetKind::Codex


### PR DESCRIPTION
The agent preset tabs (Codex, Claude, Pi, etc.) had inconsistent icon slot sizes - Codex used 20px while others used 14px. This caused vertical misalignment in the tab bar.

Fix: Use a consistent 20px slot size for all preset icons, regardless of actual icon size. Icons are still centered within the slot.

Closes #30 