### PR TITLE
fix: use server-side window decorations on Linux

### DIFF
--- a/crates/arbor-gui/src/app_bootstrap.rs
+++ b/crates/arbor-gui/src/app_bootstrap.rs
@@ -10,7 +10,7 @@ fn open_arbor_window(cx: &mut App) {
                 appears_transparent: true,
                 traffic_light_position: Some(point(px(9.), px(9.))),
             }),
-            window_decorations: Some(WindowDecorations::Client),
+            window_decorations: Some(DEFAULT_WINDOW_DECORATIONS),
             ..Default::default()
         },
         |_, cx| {
@@ -492,7 +492,7 @@ fn main() {
                     appears_transparent: true,
                     traffic_light_position: Some(point(px(9.), px(9.))),
                 }),
-                window_decorations: Some(WindowDecorations::Client),
+                window_decorations: Some(DEFAULT_WINDOW_DECORATIONS),
                 ..Default::default()
             },
             move |_, cx| {

--- a/crates/arbor-gui/src/constants.rs
+++ b/crates/arbor-gui/src/constants.rs
@@ -1,5 +1,5 @@
 use {
-    gpui::{App, FontFallbacks, FontFeatures, font},
+    gpui::{App, FontFallbacks, FontFeatures, WindowDecorations, font},
     std::{
         borrow::Cow,
         env, fs,
@@ -41,6 +41,11 @@ pub(crate) const TITLEBAR_HEIGHT: f32 = 34.;
 pub(crate) const TOP_BAR_LEFT_OFFSET: f32 = 76.;
 #[cfg(not(target_os = "macos"))]
 pub(crate) const TOP_BAR_LEFT_OFFSET: f32 = 8.;
+
+#[cfg(target_os = "linux")]
+pub(crate) const DEFAULT_WINDOW_DECORATIONS: WindowDecorations = WindowDecorations::Server;
+#[cfg(not(target_os = "linux"))]
+pub(crate) const DEFAULT_WINDOW_DECORATIONS: WindowDecorations = WindowDecorations::Client;
 
 pub(crate) const WORKTREE_AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 pub(crate) const GITHUB_PR_REFRESH_INTERVAL: Duration = Duration::from_secs(30);

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -40,9 +40,8 @@ use {
         Image, ImageFormat, KeyBinding, KeyDownEvent, Keystroke, Menu, MenuItem, MouseButton,
         MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels, ScrollHandle,
         ScrollStrategy, Stateful, SystemMenuType, TextRun, TitlebarOptions, UTF16Selection,
-        UniformListScrollHandle, Window, WindowBounds, WindowControlArea, WindowDecorations,
-        WindowOptions, canvas, div, ease_in_out, fill, img, point, prelude::*, px, rgb, size,
-        uniform_list,
+        UniformListScrollHandle, Window, WindowBounds, WindowControlArea, WindowOptions, canvas,
+        div, ease_in_out, fill, img, point, prelude::*, px, rgb, size, uniform_list,
     },
     ropey::Rope,
     std::{


### PR DESCRIPTION
On Linux, GPUI's client-side decoration (CSD) support is incomplete: the hit-test callback for window control areas is a no-op on both Wayland and X11, so close/minimize/maximize buttons never appear and the custom drag region doesn't function.

This switches Linux to server-side decorations (SSD) so the compositor or window manager provides native titlebar controls, drag, and resize. macOS and Windows remain on CSD.

## Changes

- Added a platform-conditional `DEFAULT_WINDOW_DECORATIONS` constant in `constants.rs` (`Server` on Linux, `Client` elsewhere)
- Updated both window-open paths (startup in `main.rs` and new-window in `helpers.rs`) to use it

## Testing

Verified working on COSMIC desktop (Wayland compositor with full SSD titlebar support).

Note: compositors like niri that don't render traditional SSD titlebars will still lack visible close/min/max buttons — this is compositor behavior, not an app issue. Full Linux CSD (app-drawn window controls) is a longer-term goal.