### PR TITLE
Add richer PR details to the changes pane

### DIFF
--- a/crates/arbor-gui/src/changes_pane.rs
+++ b/crates/arbor-gui/src/changes_pane.rs
@@ -265,6 +265,9 @@ impl ArborWindow {
                     .flex_col()
                     .font_family(FONT_MONO)
                     .p_1()
+                    .when_some(self.render_changes_worktree_summary(cx), |this, summary| {
+                        this.child(summary)
+                    })
                     .children(filtered_changes.iter().map(|change| {
                         let is_selected = selected_path
                             .as_ref()

--- a/crates/arbor-gui/src/github_service.rs
+++ b/crates/arbor-gui/src/github_service.rs
@@ -28,7 +28,26 @@ pub enum CheckStatus {
     Pending,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeableState {
+    Conflicting,
+    Mergeable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeStateStatus {
+    Behind,
+    Blocked,
+    Clean,
+    Dirty,
+    Draft,
+    HasHooks,
+    Unknown,
+    Unstable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrDetails {
     pub number: u64,
     pub title: String,
@@ -37,6 +56,9 @@ pub struct PrDetails {
     pub additions: usize,
     pub deletions: usize,
     pub review_decision: ReviewDecision,
+    pub mergeable: MergeableState,
+    pub merge_state_status: MergeStateStatus,
+    pub passed_checks: usize,
     pub checks_status: CheckStatus,
     pub checks: Vec<(String, CheckStatus)>,
 }
@@ -52,6 +74,8 @@ struct GhPrResponse {
     additions: usize,
     deletions: usize,
     review_decision: Option<String>,
+    mergeable: Option<String>,
+    merge_state_status: Option<String>,
     #[serde(default)]
     status_check_rollup: Vec<GhCheckContext>,
 }
@@ -138,12 +162,31 @@ fn parse_pr_details(response: GhPrResponse) -> PrDetails {
         Some("CHANGES_REQUESTED") => ReviewDecision::ChangesRequested,
         _ => ReviewDecision::Pending,
     };
+    let mergeable = match response.mergeable.as_deref() {
+        Some("CONFLICTING") => MergeableState::Conflicting,
+        Some("MERGEABLE") => MergeableState::Mergeable,
+        _ => MergeableState::Unknown,
+    };
+    let merge_state_status = match response.merge_state_status.as_deref() {
+        Some("BEHIND") => MergeStateStatus::Behind,
+        Some("BLOCKED") => MergeStateStatus::Blocked,
+        Some("CLEAN") => MergeStateStatus::Clean,
+        Some("DIRTY") => MergeStateStatus::Dirty,
+        Some("DRAFT") => MergeStateStatus::Draft,
+        Some("HAS_HOOKS") => MergeStateStatus::HasHooks,
+        Some("UNSTABLE") => MergeStateStatus::Unstable,
+        _ => MergeStateStatus::Unknown,
+    };
 
-    let checks: Vec<(String, CheckStatus)> = response
+    let mut checks: Vec<(String, CheckStatus)> = response
         .status_check_rollup
         .iter()
         .map(|c| (c.display_name(), c.to_check_status()))
         .collect();
+    let passed_checks = checks
+        .iter()
+        .filter(|(_, status)| *status == CheckStatus::Success)
+        .count();
 
     let checks_status = if checks.is_empty() {
         CheckStatus::Pending
@@ -154,6 +197,7 @@ fn parse_pr_details(response: GhPrResponse) -> PrDetails {
     } else {
         CheckStatus::Pending
     };
+    sort_checks_for_display(&mut checks);
 
     PrDetails {
         number: response.number,
@@ -163,8 +207,27 @@ fn parse_pr_details(response: GhPrResponse) -> PrDetails {
         additions: response.additions,
         deletions: response.deletions,
         review_decision,
+        mergeable,
+        merge_state_status,
+        passed_checks,
         checks_status,
         checks,
+    }
+}
+
+fn sort_checks_for_display(checks: &mut [(String, CheckStatus)]) {
+    checks.sort_by(|left, right| {
+        check_status_sort_key(left.1)
+            .cmp(&check_status_sort_key(right.1))
+            .then(left.0.cmp(&right.0))
+    });
+}
+
+fn check_status_sort_key(status: CheckStatus) -> usize {
+    match status {
+        CheckStatus::Failure => 0,
+        CheckStatus::Pending => 1,
+        CheckStatus::Success => 2,
     }
 }
 
@@ -178,7 +241,7 @@ pub fn pull_request_details(repo_slug: &str, branch: &str) -> Option<PrDetails> 
             "--repo",
             repo_slug,
             "--json",
-            "number,title,url,state,isDraft,additions,deletions,reviewDecision,statusCheckRollup",
+            "number,title,url,state,isDraft,additions,deletions,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup",
             branch,
         ])
         .stdin(Stdio::null())
@@ -421,7 +484,8 @@ pub(crate) fn parse_pull_request_number(reference: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CheckStatus, GhCheckContext, GhPrResponse, parse_pr_details, parse_pull_request_number,
+        CheckStatus, GhCheckContext, GhPrResponse, MergeStateStatus, MergeableState,
+        parse_pr_details, parse_pull_request_number,
     };
 
     #[test]
@@ -435,6 +499,8 @@ mod tests {
             additions: 10,
             deletions: 2,
             review_decision: None,
+            mergeable: Some("MERGEABLE".to_owned()),
+            merge_state_status: Some("CLEAN".to_owned()),
             status_check_rollup: vec![
                 GhCheckContext {
                     name: Some("Clippy".to_owned()),
@@ -454,6 +520,9 @@ mod tests {
         });
 
         assert_eq!(details.checks_status, CheckStatus::Pending);
+        assert_eq!(details.passed_checks, 0);
+        assert_eq!(details.mergeable, MergeableState::Mergeable);
+        assert_eq!(details.merge_state_status, MergeStateStatus::Clean);
         assert_eq!(details.checks, vec![
             ("Clippy".to_owned(), CheckStatus::Pending),
             ("Test".to_owned(), CheckStatus::Pending),

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -50,7 +50,10 @@ use {
         net::TcpListener,
         path::{Path, PathBuf},
         process::{Child, Command, Stdio},
-        sync::{Arc, Mutex, OnceLock},
+        sync::{
+            Arc, Mutex, OnceLock,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::{Duration, Instant, SystemTime},
     },
     syntect::{easy::HighlightLines, highlighting::ThemeSet, parsing::SyntaxSet},
@@ -76,6 +79,7 @@ include!("daemon_connection_ui.rs");
 include!("settings_ui.rs");
 include!("top_bar.rs");
 include!("sidebar.rs");
+include!("pr_summary_ui.rs");
 include!("changes_pane.rs");
 include!("log_view.rs");
 include!("center_panel.rs");
@@ -222,6 +226,7 @@ impl ArborWindow {
                     worktrees: Vec::new(),
                     worktree_stats_loading: false,
                     worktree_prs_loading: false,
+                    expanded_pr_checks_worktree: None,
                     active_worktree_index: None,
                     worktree_selection_epoch: 0,
                     changed_files: Vec::new(),
@@ -564,6 +569,7 @@ impl ArborWindow {
             worktrees: Vec::new(),
             worktree_stats_loading: false,
             worktree_prs_loading: false,
+            expanded_pr_checks_worktree: None,
             active_worktree_index: None,
             worktree_selection_epoch: 0,
             changed_files: Vec::new(),
@@ -2242,6 +2248,10 @@ impl ArborWindow {
                 )
             })
             .collect();
+        let tracked_paths: HashSet<PathBuf> = tracked_branches
+            .iter()
+            .map(|(path, ..)| path.clone())
+            .collect();
         let github_token = self.github_access_token();
         let github_service = self.github_service.clone();
 
@@ -2262,81 +2272,103 @@ impl ArborWindow {
         }
 
         self.worktree_prs_loading = true;
-        cx.spawn(async move |this, cx| {
-            let results = cx
-                .background_spawn(async move {
-                    tracked_branches
-                        .into_iter()
-                        .map(|(path, branch, repo_slug)| {
-                            // Try gh CLI first for rich details
-                            let details = repo_slug.as_ref().and_then(|slug| {
-                                github_service::pull_request_details(slug, &branch)
-                            });
+        let mut cleared_untracked = false;
+        for worktree in &mut self.worktrees {
+            if tracked_paths.contains(&worktree.path) {
+                continue;
+            }
+            if worktree.pr_number.take().is_some()
+                || worktree.pr_url.take().is_some()
+                || worktree.pr_details.take().is_some()
+            {
+                cleared_untracked = true;
+            }
+        }
+        if cleared_untracked {
+            cx.notify();
+        }
 
-                            let (pr_number, pr_url) = if let Some(ref d) = details {
-                                (Some(d.number), Some(d.url.clone()))
-                            } else {
-                                // Fall back to octocrab for just the number
-                                let num = repo_slug.as_ref().and_then(|_| {
-                                    github_pr_number_for_worktree(
-                                        github_service.as_ref(),
-                                        &path,
-                                        &branch,
-                                        github_token.as_deref(),
-                                    )
-                                });
-                                let url = num.and_then(|n| {
-                                    repo_slug.as_ref().map(|slug| github_pr_url(slug, n))
-                                });
-                                (num, url)
-                            };
+        let pending_results = Arc::new(AtomicUsize::new(tracked_branches.len()));
+        for (path, branch, repo_slug) in tracked_branches {
+            let github_service = github_service.clone();
+            let github_token = github_token.clone();
+            let pending_results = pending_results.clone();
 
-                            (path, pr_number, pr_url, details)
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .await;
+            cx.spawn(async move |this, cx| {
+                let result = cx
+                    .background_spawn(async move {
+                        Self::lookup_worktree_pull_request(
+                            github_service.as_ref(),
+                            github_token.as_deref(),
+                            path,
+                            branch,
+                            repo_slug,
+                        )
+                    })
+                    .await;
 
-            let _ = this.update(cx, |this, cx| {
-                this.worktree_prs_loading = false;
+                let is_last_result = pending_results.fetch_sub(1, Ordering::SeqCst) == 1;
 
-                type PrInfo = (
-                    Option<u64>,
-                    Option<String>,
-                    Option<github_service::PrDetails>,
-                );
-                let pr_by_path: HashMap<PathBuf, PrInfo> = results
-                    .into_iter()
-                    .map(|(path, num, url, details)| (path, (num, url, details)))
-                    .collect();
+                let _ = this.update(cx, |this, cx| {
+                    let (path, next_num, next_url, next_details) = result;
+                    let mut changed = false;
 
-                let mut changed = false;
-
-                for worktree in &mut this.worktrees {
-                    let (next_num, next_url, next_details) = pr_by_path
-                        .get(&worktree.path)
-                        .cloned()
-                        .unwrap_or((None, None, None));
-                    if worktree.pr_number != next_num || worktree.pr_url != next_url {
+                    if let Some(worktree) = this
+                        .worktrees
+                        .iter_mut()
+                        .find(|worktree| worktree.path == path)
+                        && (worktree.pr_number != next_num
+                            || worktree.pr_url != next_url
+                            || worktree.pr_details != next_details)
+                    {
                         worktree.pr_number = next_num;
                         worktree.pr_url = next_url;
+                        worktree.pr_details = next_details;
                         changed = true;
                     }
-                    // Always update pr_details (no PartialEq on PrDetails)
-                    let had_details = worktree.pr_details.is_some();
-                    let has_details = next_details.is_some();
-                    worktree.pr_details = next_details;
-                    if had_details != has_details {
-                        changed = true;
-                    }
-                }
 
-                if changed {
-                    cx.notify();
-                }
+                    if is_last_result {
+                        this.worktree_prs_loading = false;
+                        changed = true;
+                    }
+
+                    if changed {
+                        cx.notify();
+                    }
+                });
+            })
+            .detach();
+        }
+    }
+
+    fn lookup_worktree_pull_request(
+        github_service: &dyn github_service::GitHubService,
+        github_token: Option<&str>,
+        path: PathBuf,
+        branch: String,
+        repo_slug: Option<String>,
+    ) -> (
+        PathBuf,
+        Option<u64>,
+        Option<String>,
+        Option<github_service::PrDetails>,
+    ) {
+        let details = repo_slug
+            .as_ref()
+            .and_then(|slug| github_service::pull_request_details(slug, &branch));
+
+        let (pr_number, pr_url) = if let Some(ref details) = details {
+            (Some(details.number), Some(details.url.clone()))
+        } else {
+            let pr_number = repo_slug.as_ref().and_then(|_| {
+                github_pr_number_for_worktree(github_service, &path, &branch, github_token)
             });
-        })
-        .detach();
+            let pr_url = pr_number
+                .and_then(|number| repo_slug.as_ref().map(|slug| github_pr_url(slug, number)));
+            (pr_number, pr_url)
+        };
+
+        (path, pr_number, pr_url, details)
     }
 
     fn switch_terminal_backend(
@@ -7283,7 +7315,8 @@ mod tests {
             build_side_by_side_diff_lines,
             checkout::CheckoutKind,
             estimated_worktree_hover_popover_card_height, extract_first_url,
-            resolve_github_access_token_from_sources, styled_lines_for_session,
+            prioritized_pr_checks_for_display, resolve_github_access_token_from_sources,
+            styled_lines_for_session,
             terminal_backend::{
                 TerminalCursor, TerminalModes, TerminalStyledCell, TerminalStyledLine,
                 TerminalStyledRun,
@@ -7624,6 +7657,9 @@ mod tests {
             additions: 12,
             deletions: 4,
             review_decision: crate::github_service::ReviewDecision::Pending,
+            mergeable: crate::github_service::MergeableState::Mergeable,
+            merge_state_status: crate::github_service::MergeStateStatus::Clean,
+            passed_checks: 1,
             checks_status: crate::github_service::CheckStatus::Pending,
             checks: vec![
                 ("ci".to_owned(), crate::github_service::CheckStatus::Pending),
@@ -7657,6 +7693,62 @@ mod tests {
 
         assert!(expanded > collapsed);
         assert!(expanded_bounds.size.height > collapsed_bounds.size.height);
+    }
+
+    #[test]
+    fn prioritized_pr_checks_show_failures_before_pending_before_successes() {
+        let pr = crate::github_service::PrDetails {
+            number: 7,
+            title: "Sort checks".to_owned(),
+            url: "https://example.com/pr/7".to_owned(),
+            state: crate::github_service::PrState::Open,
+            additions: 1,
+            deletions: 1,
+            review_decision: crate::github_service::ReviewDecision::Pending,
+            mergeable: crate::github_service::MergeableState::Mergeable,
+            merge_state_status: crate::github_service::MergeStateStatus::Clean,
+            passed_checks: 2,
+            checks_status: crate::github_service::CheckStatus::Pending,
+            checks: vec![
+                (
+                    "b-failure".to_owned(),
+                    crate::github_service::CheckStatus::Failure,
+                ),
+                (
+                    "a-pending".to_owned(),
+                    crate::github_service::CheckStatus::Pending,
+                ),
+                (
+                    "a-success".to_owned(),
+                    crate::github_service::CheckStatus::Success,
+                ),
+                (
+                    "z-success".to_owned(),
+                    crate::github_service::CheckStatus::Success,
+                ),
+            ],
+        };
+
+        let checks = prioritized_pr_checks_for_display(&pr);
+
+        assert_eq!(checks, &[
+            (
+                "b-failure".to_owned(),
+                crate::github_service::CheckStatus::Failure
+            ),
+            (
+                "a-pending".to_owned(),
+                crate::github_service::CheckStatus::Pending
+            ),
+            (
+                "a-success".to_owned(),
+                crate::github_service::CheckStatus::Success
+            ),
+            (
+                "z-success".to_owned(),
+                crate::github_service::CheckStatus::Success
+            ),
+        ]);
     }
 
     #[test]

--- a/crates/arbor-gui/src/pr_summary_ui.rs
+++ b/crates/arbor-gui/src/pr_summary_ui.rs
@@ -1,0 +1,577 @@
+const MAX_VISIBLE_PR_CHECKS: usize = 6;
+
+impl ArborWindow {
+    fn render_changes_worktree_summary(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let worktree = self.active_worktree()?;
+        let theme = self.theme();
+        let attention = worktree_attention_indicator(worktree);
+        let repo_slug = self.github_repo_slug.clone();
+        let relative_time = worktree.last_activity_unix_ms.map(format_relative_time);
+        let diff_summary = worktree.diff_summary;
+        let branch_divergence = worktree.branch_divergence;
+        let has_ports = !worktree.detected_ports.is_empty();
+        let checks_expanded = self
+            .expanded_pr_checks_worktree
+            .as_ref()
+            .is_some_and(|path| path == &worktree.path);
+
+        let mut card = div()
+            .id("changes-worktree-summary")
+            .mx_1()
+            .mt_1()
+            .mb_2()
+            .p_2()
+            .font_family(FONT_MONO)
+            .bg(rgb(theme.panel_bg))
+            .border_1()
+            .border_color(rgb(theme.border))
+            .rounded_md()
+            .flex()
+            .flex_col()
+            .gap_1();
+
+        card = card.child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap_2()
+                .child(
+                    div()
+                        .min_w_0()
+                        .flex_1()
+                        .overflow_hidden()
+                        .whitespace_nowrap()
+                        .text_ellipsis()
+                        .text_xs()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(rgb(theme.text_primary))
+                        .child(worktree.branch.clone()),
+                )
+                .when_some(relative_time, |this, relative_time| {
+                    this.child(
+                        div()
+                            .flex_none()
+                            .text_xs()
+                            .text_color(rgb(theme.text_disabled))
+                            .child(relative_time),
+                    )
+                }),
+        );
+
+        let subtitle = repo_slug
+            .map(|slug| format!("{} · {}", worktree.label, slug))
+            .unwrap_or_else(|| worktree.label.clone());
+        card = card.child(
+            div()
+                .text_xs()
+                .text_color(rgb(theme.text_muted))
+                .child(subtitle),
+        );
+
+        let mut meta_row = div().flex().items_center().flex_wrap().gap_1();
+        meta_row = meta_row.child(
+            div()
+                .px_1()
+                .py(px(2.))
+                .rounded_sm()
+                .text_xs()
+                .text_color(rgb(attention.color))
+                .bg(rgb(theme.sidebar_bg))
+                .child(attention.label),
+        );
+
+        if let Some(summary) = diff_summary
+            && (summary.additions > 0 || summary.deletions > 0)
+        {
+            let mut diff_chip = div()
+                .px_1()
+                .py(px(2.))
+                .rounded_sm()
+                .bg(rgb(theme.sidebar_bg))
+                .flex()
+                .items_center()
+                .gap_1();
+            if summary.additions > 0 {
+                diff_chip = diff_chip.child(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(0x72d69c))
+                        .child(format!("+{}", summary.additions)),
+                );
+            }
+            if summary.deletions > 0 {
+                diff_chip = diff_chip.child(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(0xeb6f92))
+                        .child(format!("-{}", summary.deletions)),
+                );
+            }
+            meta_row = meta_row.child(diff_chip);
+        }
+
+        if let Some(divergence) = branch_divergence {
+            if divergence.ahead > 0 {
+                meta_row = meta_row.child(
+                    div()
+                        .px_1()
+                        .py(px(2.))
+                        .rounded_sm()
+                        .bg(rgb(theme.sidebar_bg))
+                        .text_xs()
+                        .text_color(rgb(0x72d69c))
+                        .child(format!("\u{2191}{}", divergence.ahead)),
+                );
+            }
+            if divergence.behind > 0 {
+                meta_row = meta_row.child(
+                    div()
+                        .px_1()
+                        .py(px(2.))
+                        .rounded_sm()
+                        .bg(rgb(theme.sidebar_bg))
+                        .text_xs()
+                        .text_color(rgb(0xe5c07b))
+                        .child(format!("\u{2193}{}", divergence.behind)),
+                );
+            }
+        }
+
+        if has_ports {
+            meta_row = meta_row.child(
+                div()
+                    .px_1()
+                    .py(px(2.))
+                    .rounded_sm()
+                    .bg(rgb(theme.sidebar_bg))
+                    .text_xs()
+                    .text_color(rgb(0x72d69c))
+                    .child(format!(
+                        "{} port{}",
+                        worktree.detected_ports.len(),
+                        if worktree.detected_ports.len() == 1 {
+                            ""
+                        } else {
+                            "s"
+                        }
+                    )),
+            );
+        }
+
+        if self.worktree_prs_loading {
+            meta_row = meta_row.child(pr_loading_chip(&theme, "Refreshing PR"));
+        }
+
+        card = card.child(meta_row);
+
+        if let Some(pr) = worktree.pr_details.as_ref() {
+            let (state_label, state_color) = pr_state_presentation(&theme, pr.state);
+            let (passed_checks, total_checks) = pr_check_counts(pr);
+            let review = review_status_presentation(pr.review_decision);
+            let merge_status = merge_status_presentation(&theme, pr);
+            let visible_checks = if checks_expanded {
+                sorted_pr_checks_for_display(pr)
+            } else {
+                prioritized_pr_checks_for_display(pr)
+            };
+            let hidden_check_count = pr.checks.len().saturating_sub(visible_checks.len());
+            let can_toggle_checks = pr.checks.len() > MAX_VISIBLE_PR_CHECKS || checks_expanded;
+            let pr_url = pr.url.clone();
+
+            card = card.child(div().h(px(1.)).bg(rgb(theme.border)).my_1());
+            card = card.child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .id("changes-summary-pr-link")
+                                    .cursor_pointer()
+                                    .text_xs()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(rgb(theme.accent))
+                                    .hover(|this| this.text_color(rgb(theme.text_primary)))
+                                    .child(format!("#{}", pr.number))
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.open_external_url(&pr_url, cx);
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .px_1()
+                                    .rounded_sm()
+                                    .text_xs()
+                                    .text_color(rgb(state_color))
+                                    .child(state_label),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(rgb(0x72d69c))
+                                    .child(format!("+{}", pr.additions)),
+                            )
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(rgb(0xeb6f92))
+                                    .child(format!("-{}", pr.deletions)),
+                            ),
+                    ),
+            );
+            card = card.child(
+                div()
+                    .text_xs()
+                    .text_color(rgb(theme.text_muted))
+                    .child(pr.title.clone()),
+            );
+
+            let mut status_row = div().flex().items_center().flex_wrap().gap_2();
+            if total_checks > 0 {
+                let (icon, color) = check_status_presentation(pr.checks_status);
+                let worktree_path = worktree.path.clone();
+                let mut checks_summary = div()
+                    .flex()
+                    .items_center()
+                    .gap(px(3.))
+                    .child(div().text_xs().text_color(rgb(color)).child(icon))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(rgb(theme.text_muted))
+                            .child(format!("{passed_checks}/{total_checks} checks")),
+                    );
+
+                if can_toggle_checks {
+                    checks_summary = checks_summary
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(rgb(theme.text_disabled))
+                                .child(if checks_expanded {
+                                    "\u{f078}"
+                                } else {
+                                    "\u{f054}"
+                                }),
+                        )
+                        .cursor_pointer()
+                        .hover(|this| this.bg(rgb(theme.sidebar_bg)))
+                        .rounded_sm()
+                        .px_1()
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                                this.toggle_changes_pr_checks_for_worktree(
+                                    worktree_path.clone(),
+                                    cx,
+                                );
+                            }),
+                        );
+                }
+
+                status_row = status_row.child(checks_summary);
+            }
+            status_row = status_row.child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(3.))
+                    .child(div().text_xs().text_color(rgb(review.2)).child(review.0))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(rgb(review.2))
+                            .child(review.1),
+                    ),
+            );
+            status_row = status_row.child(
+                div()
+                    .text_xs()
+                    .text_color(rgb(merge_status.1))
+                    .child(merge_status.0),
+            );
+            card = card.child(status_row);
+
+            if !visible_checks.is_empty() {
+                let mut checks_list = div().flex().flex_col().gap(px(3.)).pl_1();
+                for (name, status) in visible_checks.iter() {
+                    let (icon, color) = check_status_presentation(*status);
+                    checks_list = checks_list.child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap(px(4.))
+                            .child(div().text_xs().text_color(rgb(color)).child(icon))
+                            .child(
+                                div()
+                                    .min_w_0()
+                                    .flex_1()
+                                    .overflow_hidden()
+                                    .whitespace_nowrap()
+                                    .text_ellipsis()
+                                    .text_xs()
+                                    .text_color(rgb(theme.text_muted))
+                                    .child(name.clone()),
+                            ),
+                    );
+                }
+                if can_toggle_checks {
+                    let worktree_path = worktree.path.clone();
+                    let toggle_label = if checks_expanded {
+                        "Hide checks".to_owned()
+                    } else {
+                        format!("+{hidden_check_count} more checks")
+                    };
+                    checks_list = checks_list.child(
+                        div()
+                            .cursor_pointer()
+                            .hover(|this| this.bg(rgb(theme.sidebar_bg)))
+                            .rounded_sm()
+                            .px_1()
+                            .flex()
+                            .items_center()
+                            .gap(px(4.))
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(rgb(theme.text_disabled))
+                                    .child(if checks_expanded {
+                                        "\u{f078}"
+                                    } else {
+                                        "\u{f054}"
+                                    }),
+                            )
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(rgb(theme.text_disabled))
+                                    .child(toggle_label),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                                    this.toggle_changes_pr_checks_for_worktree(
+                                        worktree_path.clone(),
+                                        cx,
+                                    );
+                                }),
+                            ),
+                    );
+                }
+                card = card.child(checks_list);
+            }
+        } else {
+            card = card.child(div().h(px(1.)).bg(rgb(theme.border)).my_1());
+
+            if self.worktree_prs_loading {
+                card = card.child(pr_loading_row(&theme, "Refreshing PR details"));
+            }
+
+            if let Some(pr_url) = worktree.pr_url.clone() {
+                let pr_number = worktree.pr_number;
+                card = card.child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            div()
+                                .id("changes-summary-pr-fallback-link")
+                                .cursor_pointer()
+                                .text_xs()
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(rgb(theme.accent))
+                                .hover(|this| this.text_color(rgb(theme.text_primary)))
+                                .child(match pr_number {
+                                    Some(number) => format!("#{}", number),
+                                    None => "Pull request".to_owned(),
+                                })
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.open_external_url(&pr_url, cx);
+                                })),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(rgb(theme.text_disabled))
+                                .child(if self.worktree_prs_loading {
+                                    "Fetching GitHub details"
+                                } else {
+                                    "GitHub details unavailable"
+                                }),
+                        ),
+                );
+            } else if !self.worktree_prs_loading {
+                card = card.child(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(theme.text_disabled))
+                        .child("No pull request for this branch"),
+                );
+            }
+        }
+
+        Some(card.into_any_element())
+    }
+
+    fn toggle_changes_pr_checks_for_worktree(
+        &mut self,
+        worktree_path: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
+        if self.expanded_pr_checks_worktree.as_ref() == Some(&worktree_path) {
+            self.expanded_pr_checks_worktree = None;
+        } else {
+            self.expanded_pr_checks_worktree = Some(worktree_path);
+        }
+        cx.notify();
+    }
+}
+
+fn pr_state_presentation(
+    theme: &ThemePalette,
+    state: github_service::PrState,
+) -> (&'static str, u32) {
+    match state {
+        github_service::PrState::Open => ("Open", 0x72d69c_u32),
+        github_service::PrState::Draft => ("Draft", theme.text_disabled),
+        github_service::PrState::Merged => ("Merged", 0xbb9af7_u32),
+        github_service::PrState::Closed => ("Closed", 0xeb6f92_u32),
+    }
+}
+
+fn review_status_presentation(
+    review_decision: github_service::ReviewDecision,
+) -> (&'static str, &'static str, u32) {
+    match review_decision {
+        github_service::ReviewDecision::Approved => ("\u{f00c}", "Approved", 0x72d69c_u32),
+        github_service::ReviewDecision::ChangesRequested => {
+            ("\u{f00d}", "Changes requested", 0xeb6f92_u32)
+        },
+        github_service::ReviewDecision::Pending => ("\u{f192}", "Needs review", 0xe5c07b_u32),
+    }
+}
+
+fn merge_status_presentation(
+    theme: &ThemePalette,
+    pr: &github_service::PrDetails,
+) -> (&'static str, u32) {
+    use crate::github_service::{MergeStateStatus, MergeableState, PrState};
+
+    match pr.state {
+        PrState::Merged => ("Merged", 0xbb9af7_u32),
+        PrState::Closed => ("Closed", 0xeb6f92_u32),
+        PrState::Draft => ("Draft", theme.text_disabled),
+        PrState::Open => {
+            if pr.mergeable == MergeableState::Conflicting
+                || pr.merge_state_status == MergeStateStatus::Dirty
+            {
+                return ("Merge conflicts", 0xeb6f92_u32);
+            }
+
+            match pr.merge_state_status {
+                MergeStateStatus::Behind => ("Update branch", 0xe5c07b_u32),
+                MergeStateStatus::Blocked => ("Merge blocked", 0xe5c07b_u32),
+                MergeStateStatus::Clean | MergeStateStatus::HasHooks => {
+                    ("Ready to merge", 0x72d69c_u32)
+                }
+                MergeStateStatus::Dirty => ("Merge conflicts", 0xeb6f92_u32),
+                MergeStateStatus::Draft => ("Draft", theme.text_disabled),
+                MergeStateStatus::Unknown => match pr.mergeable {
+                    MergeableState::Conflicting => ("Merge conflicts", 0xeb6f92_u32),
+                    MergeableState::Mergeable => ("Ready to merge", 0x72d69c_u32),
+                    MergeableState::Unknown => ("Checking mergeability", theme.text_disabled),
+                },
+                MergeStateStatus::Unstable => ("Checks failing", 0xeb6f92_u32),
+            }
+        }
+    }
+}
+
+fn check_status_presentation(status: github_service::CheckStatus) -> (&'static str, u32) {
+    match status {
+        github_service::CheckStatus::Success => ("\u{f00c}", 0x72d69c_u32),
+        github_service::CheckStatus::Failure => ("\u{f00d}", 0xeb6f92_u32),
+        github_service::CheckStatus::Pending => ("\u{f192}", 0xe5c07b_u32),
+    }
+}
+
+fn pr_check_counts(pr: &github_service::PrDetails) -> (usize, usize) {
+    (pr.passed_checks, pr.checks.len())
+}
+
+fn prioritized_pr_checks_for_display(
+    pr: &github_service::PrDetails,
+) -> &[(String, github_service::CheckStatus)] {
+    let visible_check_count = pr.checks.len().min(MAX_VISIBLE_PR_CHECKS);
+    &pr.checks[..visible_check_count]
+}
+
+fn sorted_pr_checks_for_display(
+    pr: &github_service::PrDetails,
+) -> &[(String, github_service::CheckStatus)] {
+    pr.checks.as_slice()
+}
+
+fn pr_loading_chip(theme: &ThemePalette, label: &'static str) -> AnyElement {
+    div()
+        .px_1()
+        .py(px(2.))
+        .rounded_sm()
+        .bg(rgb(theme.sidebar_bg))
+        .flex()
+        .items_center()
+        .gap(px(4.))
+        .child(pr_loading_icon(theme, "changes-summary-pr-loading-chip"))
+        .child(
+            div()
+                .text_xs()
+                .text_color(rgb(theme.text_disabled))
+                .child(label),
+        )
+        .into_any_element()
+}
+
+fn pr_loading_row(theme: &ThemePalette, label: &'static str) -> AnyElement {
+    div()
+        .flex()
+        .items_center()
+        .gap_1()
+        .child(pr_loading_icon(theme, "changes-summary-pr-loading-row"))
+        .child(
+            div()
+                .text_xs()
+                .text_color(rgb(theme.text_disabled))
+                .child(label),
+        )
+        .into_any_element()
+}
+
+fn pr_loading_icon(theme: &ThemePalette, animation_key: &'static str) -> AnyElement {
+    div()
+        .font_family(FONT_MONO)
+        .text_xs()
+        .text_color(rgb(theme.text_disabled))
+        .child("\u{f110}")
+        .with_animation(
+            animation_key,
+            Animation::new(Duration::from_millis(900))
+                .repeat()
+                .with_easing(ease_in_out),
+            |this, delta| this.opacity(0.3 + (0.7 * delta)),
+        )
+        .into_any_element()
+}

--- a/crates/arbor-gui/src/sidebar.rs
+++ b/crates/arbor-gui/src/sidebar.rs
@@ -790,11 +790,10 @@ impl ArborWindow {
                                                                     github_service::CheckStatus::Failure => ("\u{f00d}", 0xeb6f92_u32),
                                                                     github_service::CheckStatus::Pending => ("\u{f192}", 0xe5c07b_u32),
                                                                 };
-                                                                let (review_icon, review_color) = match pr.review_decision {
-                                                                    github_service::ReviewDecision::Approved => ("\u{f00c}", 0x72d69c_u32),
-                                                                    github_service::ReviewDecision::ChangesRequested => ("\u{f071}", 0xeb6f92_u32),
-                                                                    github_service::ReviewDecision::Pending => ("\u{f128}", theme.text_disabled),
-                                                                };
+                                                                let (review_icon, _, review_color) =
+                                                                    review_status_presentation(
+                                                                        pr.review_decision,
+                                                                    );
 
                                                                 let mut badges = this.child(
                                                                     div()
@@ -2108,12 +2107,7 @@ impl ArborWindow {
         if let Some(ref pr) = worktree.pr_details {
             card = card.child(div().h(px(1.)).bg(rgb(theme.border)).my_1());
 
-            let (state_label, state_color) = match pr.state {
-                github_service::PrState::Open => ("Open", 0x72d69c_u32),
-                github_service::PrState::Draft => ("Draft", theme.text_disabled),
-                github_service::PrState::Merged => ("Merged", 0xbb9af7_u32),
-                github_service::PrState::Closed => ("Closed", 0xeb6f92_u32),
-            };
+            let (state_label, state_color) = pr_state_presentation(&theme, pr.state);
 
             let pr_url = pr.url.clone();
             let mut pr_header = div()
@@ -2177,17 +2171,8 @@ impl ArborWindow {
                 let mut status_row = div().flex().items_center().gap_1();
 
                 if !pr.checks.is_empty() {
-                    let passed = pr
-                        .checks
-                        .iter()
-                        .filter(|(_, s)| *s == github_service::CheckStatus::Success)
-                        .count();
-                    let total = pr.checks.len();
-                    let (check_icon, check_color) = match pr.checks_status {
-                        github_service::CheckStatus::Success => ("\u{f00c}", 0x72d69c_u32),
-                        github_service::CheckStatus::Failure => ("\u{f00d}", 0xeb6f92_u32),
-                        github_service::CheckStatus::Pending => ("\u{f192}", 0xe5c07b_u32),
-                    };
+                    let (passed, total) = pr_check_counts(pr);
+                    let (check_icon, check_color) = check_status_presentation(pr.checks_status);
                     let chevron = if checks_expanded {
                         "\u{f078}"
                     } else {
@@ -2228,20 +2213,25 @@ impl ArborWindow {
                     );
                 }
 
-                let (review_label, review_color) = match pr.review_decision {
-                    github_service::ReviewDecision::Approved => ("Approved", 0x72d69c_u32),
-                    github_service::ReviewDecision::ChangesRequested => {
-                        ("Changes requested", 0xeb6f92_u32)
-                    },
-                    github_service::ReviewDecision::Pending => {
-                        ("Review pending", theme.text_disabled)
-                    },
-                };
+                let (review_icon, review_label, review_color) =
+                    review_status_presentation(pr.review_decision);
                 status_row = status_row.child(
                     div()
-                        .text_xs()
-                        .text_color(rgb(review_color))
-                        .child(review_label),
+                        .flex()
+                        .items_center()
+                        .gap(px(3.))
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(rgb(review_color))
+                                .child(review_icon),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(rgb(review_color))
+                                .child(review_label),
+                        ),
                 );
 
                 card = card.child(status_row);
@@ -2249,18 +2239,8 @@ impl ArborWindow {
                 // Expanded checks list
                 if checks_expanded {
                     let mut checks_list = div().flex().flex_col().gap(px(2.)).pl_2();
-                    let mut sorted_checks: Vec<_> = pr.checks.iter().collect();
-                    sorted_checks.sort_by_key(|(_, status)| match status {
-                        github_service::CheckStatus::Failure => 0,
-                        github_service::CheckStatus::Pending => 1,
-                        github_service::CheckStatus::Success => 2,
-                    });
-                    for (name, status) in sorted_checks {
-                        let (icon, color) = match status {
-                            github_service::CheckStatus::Success => ("\u{f00c}", 0x72d69c_u32),
-                            github_service::CheckStatus::Failure => ("\u{f00d}", 0xeb6f92_u32),
-                            github_service::CheckStatus::Pending => ("\u{f192}", 0xe5c07b_u32),
-                        };
+                    for (name, status) in sorted_pr_checks_for_display(pr) {
+                        let (icon, color) = check_status_presentation(*status);
                         checks_list = checks_list.child(
                             div()
                                 .flex()

--- a/crates/arbor-gui/src/types.rs
+++ b/crates/arbor-gui/src/types.rs
@@ -159,8 +159,7 @@ impl SshTerminalShell {
                     Err(poisoned) => poisoned.into_inner(),
                 };
                 emulator.process(&data);
-                self.generation
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                self.generation.fetch_add(1, Ordering::Relaxed);
                 true
             },
             _ => false,
@@ -218,13 +217,12 @@ impl SshTerminalShell {
         if let Ok(mut emulator) = self.emulator.lock() {
             emulator.resize(rows, cols);
         }
-        self.generation
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.generation.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
     fn generation(&self) -> u64 {
-        self.generation.load(std::sync::atomic::Ordering::Relaxed)
+        self.generation.load(Ordering::Relaxed)
     }
 
     fn close(&self) {
@@ -348,25 +346,22 @@ impl DaemonTerminalWsState {
     }
 
     fn note_event(&self) {
-        self.event_generation
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.event_generation.fetch_add(1, Ordering::Relaxed);
         if let Some(ref tx) = self.poll_notify {
             let _ = tx.send(());
         }
     }
 
     fn event_generation(&self) -> u64 {
-        self.event_generation
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.event_generation.load(Ordering::Relaxed)
     }
 
     fn close(&self) {
-        self.closed
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.closed.store(true, Ordering::Relaxed);
     }
 
     fn is_closed(&self) -> bool {
-        self.closed.load(std::sync::atomic::Ordering::Relaxed)
+        self.closed.load(Ordering::Relaxed)
     }
 
     /// Try to send keystroke bytes through the WebSocket channel.
@@ -585,7 +580,7 @@ impl TerminalRuntimeHandle for DaemonTerminalRuntime {
         let current_generation = self.ws_state.event_generation();
         let last_synced_generation = self
             .last_synced_ws_generation
-            .load(std::sync::atomic::Ordering::Relaxed);
+            .load(Ordering::Relaxed);
         if current_generation > last_synced_generation {
             return is_active
                 || runtime_sync_interval_elapsed(
@@ -662,7 +657,7 @@ impl TerminalRuntimeHandle for DaemonTerminalRuntime {
         }) {
             Ok(Some(snapshot)) => {
                 self.last_synced_ws_generation
-                    .store(observed_ws_generation, std::sync::atomic::Ordering::Relaxed);
+                    .store(observed_ws_generation, Ordering::Relaxed);
                 let snapshot_state = terminal_state_from_daemon_state(snapshot.state);
                 outcome.changed |= apply_daemon_snapshot(session, &snapshot);
                 if session.state != snapshot_state {
@@ -705,7 +700,7 @@ impl TerminalRuntimeHandle for DaemonTerminalRuntime {
             },
             Ok(None) => {
                 self.last_synced_ws_generation
-                    .store(observed_ws_generation, std::sync::atomic::Ordering::Relaxed);
+                    .store(observed_ws_generation, Ordering::Relaxed);
                 outcome.close_session = true;
             },
             Err(error) => {
@@ -1516,6 +1511,7 @@ struct ArborWindow {
     worktrees: Vec<WorktreeSummary>,
     worktree_stats_loading: bool,
     worktree_prs_loading: bool,
+    expanded_pr_checks_worktree: Option<PathBuf>,
     active_worktree_index: Option<usize>,
     worktree_selection_epoch: usize,
     changed_files: Vec<ChangedFile>,

--- a/crates/arbor-web-ui/app/package-lock.json
+++ b/crates/arbor-web-ui/app/package-lock.json
@@ -855,7 +855,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -964,6 +965,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
## Summary
- add a shared PR summary card above the changes list and reuse its status presentation in the sidebar hover UI
- show richer GitHub PR state, including checks, review state, mergeability, loading feedback, and expandable check details
- fetch PR details for worktrees in parallel and precompute check ordering/counts so the UI render path avoids blocking I/O and per-render sorting

## Testing
- just format
- just lint
- cargo +nightly-2025-11-30 test -p arbor-gui prioritized_pr_checks_show_failures_before_pending_before_successes
- cargo +nightly-2025-11-30 test -p arbor-gui in_progress_checks_remain_pending_without_conclusion