### PR TITLE
Include branch info in Arbor window title

### DIFF
--- a/crates/arbor-gui/src/app_bootstrap.rs
+++ b/crates/arbor-gui/src/app_bootstrap.rs
@@ -6,7 +6,7 @@ fn open_arbor_window(cx: &mut App) {
             window_min_size: Some(size(px(1180.), px(760.))),
             app_id: Some("so.pen.arbor".to_owned()),
             titlebar: Some(TitlebarOptions {
-                title: Some("Arbor".into()),
+                title: Some(app_window_title(None).into()),
                 appears_transparent: true,
                 traffic_light_position: Some(point(px(9.), px(9.))),
             }),
@@ -488,7 +488,7 @@ fn main() {
                 window_min_size: Some(size(px(1180.), px(760.))),
                 app_id: Some("so.pen.arbor".to_owned()),
                 titlebar: Some(TitlebarOptions {
-                    title: Some("Arbor".into()),
+                    title: Some(app_window_title(None).into()),
                     appears_transparent: true,
                     traffic_light_position: Some(point(px(9.), px(9.))),
                 }),

--- a/crates/arbor-gui/src/constants.rs
+++ b/crates/arbor-gui/src/constants.rs
@@ -12,6 +12,13 @@ pub(crate) const APP_VERSION: &str = match option_env!("ARBOR_VERSION") {
     Some(v) => v,
     None => env!("CARGO_PKG_VERSION"),
 };
+pub(crate) const APP_NAME: &str = "Arbor";
+// Provided by the build environment. The repo's `just` GUI/build recipes set
+// this automatically so the title can include the branch without a build script.
+pub(crate) const APP_BUILD_BRANCH: Option<&str> = match option_env!("ARBOR_BUILD_BRANCH") {
+    Some(branch) if !branch.is_empty() => Some(branch),
+    _ => None,
+};
 
 pub(crate) const FONT_UI: &str = ".ZedSans";
 pub(crate) const FONT_MONO: &str = "CaskaydiaMono Nerd Font Mono";
@@ -119,6 +126,24 @@ pub(crate) const BUNDLED_FONT_FILES: &[&str] = &[
     "Lilex-Bold.ttf",
 ];
 
+pub(crate) fn app_window_title(connected_daemon_label: Option<&str>) -> String {
+    format_app_window_title(APP_BUILD_BRANCH, connected_daemon_label)
+}
+
+fn format_app_window_title(branch: Option<&str>, connected_daemon_label: Option<&str>) -> String {
+    let mut title = match branch.filter(|value| !value.trim().is_empty()) {
+        Some(branch) => format!("{APP_NAME} [{branch}]"),
+        None => APP_NAME.to_owned(),
+    };
+
+    if let Some(label) = connected_daemon_label.filter(|value| !value.trim().is_empty()) {
+        title.push_str(" — ");
+        title.push_str(label);
+    }
+
+    title
+}
+
 /// Load bundled fonts from disk and register them with the text system.
 ///
 /// In a macOS `.app` bundle the fonts live under `Contents/Resources/fonts/`.
@@ -211,4 +236,31 @@ pub(crate) fn terminal_mono_font(cx: &App) -> gpui::Font {
     fallback.features = FontFeatures::disable_ligatures();
     fallback.fallbacks = Some(fallbacks);
     fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_app_window_title;
+
+    #[test]
+    fn app_window_title_omits_empty_parts() {
+        assert_eq!(format_app_window_title(None, None), "Arbor");
+        assert_eq!(format_app_window_title(Some(""), Some("")), "Arbor");
+    }
+
+    #[test]
+    fn app_window_title_includes_compile_time_branch() {
+        assert_eq!(
+            format_app_window_title(Some("feature/demo"), None),
+            "Arbor [feature/demo]"
+        );
+    }
+
+    #[test]
+    fn app_window_title_keeps_daemon_label() {
+        assert_eq!(
+            format_app_window_title(Some("feature/demo"), Some("local daemon")),
+            "Arbor [feature/demo] — local daemon"
+        );
+    }
 }

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -4664,10 +4664,7 @@ impl EntityInputHandler for ArborWindow {
 impl Render for ArborWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Update window title to reflect connected daemon
-        let title = match &self.connected_daemon_label {
-            Some(label) => format!("Arbor \u{2014} {label}"),
-            None => "Arbor".to_owned(),
-        };
+        let title = app_window_title(self.connected_daemon_label.as_deref());
         window.set_window_title(&title);
 
         self.window_is_active = window.is_window_active();

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ test-ghostty-vt: ghostty-vt-bridge
     RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}" cargo +{{nightly_toolchain}} test -p arbor-terminal-emulator --features ghostty-vt-experimental
 
 check-ghostty-vt-gui: ghostty-vt-bridge
-    RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}" cargo +{{nightly_toolchain}} check -p arbor-gui --features ghostty-vt-experimental
+    ARBOR_BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)" RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}" cargo +{{nightly_toolchain}} check -p arbor-gui --features ghostty-vt-experimental
 
 check-ghostty-vt-httpd: ghostty-vt-bridge
     RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}" cargo +{{nightly_toolchain}} check -p arbor-httpd --features ghostty-vt-experimental
@@ -75,6 +75,7 @@ run-configured-embedded-engine port="": web-ui-build-if-needed ghostty-vt-bridge
     echo "daemon port: $DAEMON_PORT"
     export ARBOR_DAEMON_URL="http://127.0.0.1:${DAEMON_PORT}"
     export ARBOR_HTTPD_PORT="${DAEMON_PORT}"
+    export ARBOR_BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)"
     export RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}"
     cargo +{{nightly_toolchain}} run -p arbor-httpd --features ghostty-vt-experimental &
     HTTPD_PID=$!
@@ -94,6 +95,7 @@ run-ghostty-vt port="": web-ui-build-if-needed ghostty-vt-bridge
     export ARBOR_DAEMON_URL="http://127.0.0.1:${DAEMON_PORT}"
     export ARBOR_HTTPD_PORT="${DAEMON_PORT}"
     export ARBOR_TERMINAL_ENGINE="ghostty-vt-experimental"
+    export ARBOR_BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)"
     export RUSTFLAGS="-L native=$(pwd)/target/ghostty-vt-bridge/lib -C link-arg=-Wl,-rpath,$(pwd)/target/ghostty-vt-bridge/lib ${RUSTFLAGS:-}"
     cargo +{{nightly_toolchain}} run -p arbor-httpd --features ghostty-vt-experimental &
     HTTPD_PID=$!
@@ -112,6 +114,7 @@ run port="": web-ui-build-if-needed
     echo "daemon port: $DAEMON_PORT"
     export ARBOR_DAEMON_URL="http://127.0.0.1:${DAEMON_PORT}"
     export ARBOR_HTTPD_PORT="${DAEMON_PORT}"
+    export ARBOR_BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)"
     cargo +{{nightly_toolchain}} run -p arbor-httpd &
     HTTPD_PID=$!
     trap "kill $HTTPD_PID 2>/dev/null" EXIT
@@ -129,7 +132,7 @@ web-ui-build-if-needed:
     fi
 
 build-release: web-ui-build-if-needed
-    cargo +{{nightly_toolchain}} build --release -p arbor-gui -p arbor-httpd
+    ARBOR_BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)" cargo +{{nightly_toolchain}} build --release -p arbor-gui -p arbor-httpd
 
 run-httpd: web-ui-build-if-needed
     cargo +{{nightly_toolchain}} run -p arbor-httpd


### PR DESCRIPTION
Summary
- wire the GUI title generation through `app_window_title`, leveraging a new build-time branch constant
- add tests covering branch and daemon label formatting and inject `ARBOR_BUILD_BRANCH` via `just` recipes to avoid build scripts

Testing
- Not run (not requested)