### PR TITLE
fix(gui): force X11 on Linux Wayland to fix window management

### DIFF
--- a/crates/arbor-gui/src/app_bootstrap.rs
+++ b/crates/arbor-gui/src/app_bootstrap.rs
@@ -5,11 +5,7 @@ fn open_arbor_window(cx: &mut App) {
             window_bounds: Some(WindowBounds::Windowed(bounds)),
             window_min_size: Some(size(px(1180.), px(760.))),
             app_id: Some("so.pen.arbor".to_owned()),
-            titlebar: Some(TitlebarOptions {
-                title: Some(app_window_title(None).into()),
-                appears_transparent: true,
-                traffic_light_position: Some(point(px(9.), px(9.))),
-            }),
+            titlebar: Some(default_titlebar_options(None)),
             window_decorations: Some(DEFAULT_WINDOW_DECORATIONS),
             ..Default::default()
         },
@@ -449,6 +445,8 @@ fn main() {
         return;
     }
 
+    force_x11_on_wayland();
+
     let log_buffer = log_layer::LogBuffer::new();
 
     {
@@ -490,11 +488,7 @@ fn main() {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 window_min_size: Some(size(px(1180.), px(760.))),
                 app_id: Some("so.pen.arbor".to_owned()),
-                titlebar: Some(TitlebarOptions {
-                    title: Some(app_window_title(None).into()),
-                    appears_transparent: true,
-                    traffic_light_position: Some(point(px(9.), px(9.))),
-                }),
+                titlebar: Some(default_titlebar_options(None)),
                 window_decorations: Some(DEFAULT_WINDOW_DECORATIONS),
                 ..Default::default()
             },
@@ -518,3 +512,19 @@ fn main() {
         cx.activate(true);
     });
 }
+
+/// Force X11 (via XWayland) on Wayland sessions. GPUI's Wayland backend does not
+/// yet support server-side decoration features (resize handles, drag, close/min/max
+/// buttons), so we fall back to X11 where these work correctly.
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+fn force_x11_on_wayland() {
+    if env::var("WAYLAND_DISPLAY").is_ok_and(|v| !v.is_empty()) {
+        // SAFETY: called at the very start of main before any threads are spawned,
+        // and only when running in GUI mode (after the daemon early-return).
+        unsafe { env::remove_var("WAYLAND_DISPLAY") };
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn force_x11_on_wayland() {}

--- a/crates/arbor-gui/src/constants.rs
+++ b/crates/arbor-gui/src/constants.rs
@@ -1,5 +1,7 @@
 use {
-    gpui::{App, FontFallbacks, FontFeatures, WindowDecorations, font},
+    gpui::{
+        App, FontFallbacks, FontFeatures, SharedString, TitlebarOptions, WindowDecorations, font,
+    },
     std::{
         borrow::Cow,
         env, fs,
@@ -53,6 +55,28 @@ pub(crate) const TOP_BAR_LEFT_OFFSET: f32 = 8.;
 pub(crate) const DEFAULT_WINDOW_DECORATIONS: WindowDecorations = WindowDecorations::Server;
 #[cfg(not(target_os = "linux"))]
 pub(crate) const DEFAULT_WINDOW_DECORATIONS: WindowDecorations = WindowDecorations::Client;
+
+/// Platform-aware titlebar options. On macOS, uses a transparent titlebar with
+/// custom traffic-light positioning. On Linux (server-side decorations), these
+/// macOS-specific options are omitted so the compositor can provide native
+/// window controls, drag, and resize.
+pub(crate) fn default_titlebar_options(title: Option<SharedString>) -> TitlebarOptions {
+    #[cfg(target_os = "macos")]
+    use gpui::{point, px};
+
+    let title = title.unwrap_or_else(|| app_window_title(None).into());
+    TitlebarOptions {
+        title: Some(title),
+        #[cfg(target_os = "macos")]
+        appears_transparent: true,
+        #[cfg(not(target_os = "macos"))]
+        appears_transparent: false,
+        #[cfg(target_os = "macos")]
+        traffic_light_position: Some(point(px(9.), px(9.))),
+        #[cfg(not(target_os = "macos"))]
+        traffic_light_position: None,
+    }
+}
 
 pub(crate) const WORKTREE_AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 pub(crate) const GITHUB_PR_REFRESH_INTERVAL: Duration = Duration::from_secs(30);

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -45,9 +45,9 @@ use {
         DragMoveEvent, ElementId, ElementInputHandler, EntityInputHandler, FocusHandle, FontWeight,
         Image, ImageFormat, KeyBinding, KeyDownEvent, Keystroke, Menu, MenuItem, MouseButton,
         MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels, ScrollHandle,
-        ScrollStrategy, Stateful, SystemMenuType, TextRun, TitlebarOptions, UTF16Selection,
-        UniformListScrollHandle, Window, WindowBounds, WindowControlArea, WindowOptions, canvas,
-        div, ease_in_out, fill, img, point, prelude::*, px, rgb, size, uniform_list,
+        ScrollStrategy, Stateful, SystemMenuType, TextRun, UTF16Selection, UniformListScrollHandle,
+        Window, WindowBounds, WindowControlArea, WindowOptions, canvas, div, ease_in_out, fill,
+        img, point, prelude::*, px, rgb, size, uniform_list,
     },
     ropey::Rope,
     std::{

--- a/crates/arbor-mosh/src/shell.rs
+++ b/crates/arbor-mosh/src/shell.rs
@@ -145,28 +145,25 @@ impl MoshShell {
         let pixel_height = pixel_height.max(1);
 
         {
-            let size = self
-                .size
-                .lock()
-                .map_err(|_| MoshError::Io("failed to acquire mosh terminal size lock".to_owned()))?;
+            let size = self.size.lock().map_err(|_| {
+                MoshError::Io("failed to acquire mosh terminal size lock".to_owned())
+            })?;
             if *size == (rows, cols, pixel_width, pixel_height) {
                 return Ok(());
             }
         }
 
         {
-            let mut emulator = self
-                .emulator
-                .lock()
-                .map_err(|_| MoshError::Io("failed to acquire mosh emulator lock for resize".to_owned()))?;
+            let mut emulator = self.emulator.lock().map_err(|_| {
+                MoshError::Io("failed to acquire mosh emulator lock for resize".to_owned())
+            })?;
             emulator.resize(rows, cols);
         }
 
         {
-            let master = self
-                .master
-                .lock()
-                .map_err(|_| MoshError::Io("failed to acquire mosh PTY master lock for resize".to_owned()))?;
+            let master = self.master.lock().map_err(|_| {
+                MoshError::Io("failed to acquire mosh PTY master lock for resize".to_owned())
+            })?;
             master
                 .resize(PtySize {
                     rows,
@@ -178,10 +175,9 @@ impl MoshShell {
         }
 
         {
-            let mut size = self
-                .size
-                .lock()
-                .map_err(|_| MoshError::Io("failed to update mosh terminal size lock".to_owned()))?;
+            let mut size = self.size.lock().map_err(|_| {
+                MoshError::Io("failed to update mosh terminal size lock".to_owned())
+            })?;
             *size = (rows, cols, pixel_width, pixel_height);
         }
 


### PR DESCRIPTION
## Summary

Fixes #68 — Window cannot be resized, moved, or closed on Ubuntu 25 (Wayland).

- Force X11 backend (via XWayland) on Wayland sessions by unsetting `WAYLAND_DISPLAY` at GUI startup. GPUI v0.2.2's Wayland backend does not support server-side decoration features (resize handles, drag, close/min/max buttons).
- Make macOS-specific titlebar options (`appears_transparent: true`, `traffic_light_position`) conditional on `target_os = "macos"` so they don't interfere with server-side decorations on Linux.
- Extract `default_titlebar_options()` helper in `constants.rs` to centralize platform-aware titlebar configuration and eliminate duplication across both window creation sites.

## Changes

| File | What changed |
|------|-------------|
| `app_bootstrap.rs` | Added `force_x11_on_wayland()` — clears `WAYLAND_DISPLAY` before GUI init (after daemon early-return). Both `open_arbor_window()` and `main()` now use `default_titlebar_options()`. |
| `constants.rs` | New `default_titlebar_options()` function with `#[cfg(target_os)]` guards for `appears_transparent` and `traffic_light_position`. |
| `main.rs` | Removed unused `TitlebarOptions` import (moved to `constants.rs`). |
| `arbor-mosh/shell.rs` | Formatting-only (rustfmt). |

## Why X11 fallback instead of fixing Wayland directly?

The window management issue is in GPUI's Wayland platform layer, not in Arbor's code. Until GPUI adds proper Wayland SSD support, X11 via XWayland provides a fully functional experience. The fallback is scoped to Linux GUI mode only — daemon mode and macOS are unaffected.

## Test plan

- [x] `just format` — passes
- [x] `just lint` — zero warnings
- [x] `just test` — all tests pass
- [x] Verified on Ubuntu 25.04 (Wayland/GNOME): window has resize handles, drag, and close/min/max buttons
- [ ] Verify macOS is unaffected (no behavioral change — same `appears_transparent: true` + `traffic_light_position` as before)