### PR TITLE
fix: handle directory entries in worktree diff view

### DIFF
--- a/crates/arbor-core/src/changes.rs
+++ b/crates/arbor-core/src/changes.rs
@@ -90,6 +90,11 @@ pub fn changed_files(repo_path: &Path) -> Result<Vec<ChangedFile>, ChangesError>
 
         let rela_path_str = String::from_utf8_lossy(item.rela_path().as_ref()).into_owned();
         let path = PathBuf::from(&rela_path_str);
+
+        if repo_path.join(&path).is_dir() {
+            continue;
+        }
+
         let kind = summary_to_change_kind(summary);
 
         let line_summary =

--- a/crates/arbor-core/tests/changes_integration.rs
+++ b/crates/arbor-core/tests/changes_integration.rs
@@ -66,6 +66,38 @@ fn reports_line_level_diff_summary() {
     );
 }
 
+#[test]
+fn excludes_directory_entries_from_changed_files() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let repo_path = temp_dir.path().join("repo");
+
+    let repo = git2::Repository::init(&repo_path).expect("repo should be initialized");
+    setup_git2_config(&repo);
+
+    fs::write(repo_path.join("tracked.txt"), "hello\n").expect("tracked file should be written");
+    create_initial_commit(&repo, "initial commit");
+
+    // Create a nested git repo inside the worktree. This simulates the scenario
+    // where gix surfaces a directory path as a single status entry (e.g. submodules
+    // or nested git repositories). Previously, this directory entry would flow into
+    // the diff pipeline and cause `fs::read()` to fail with "Is a directory
+    // (os error 21)" when the user clicked on it.
+    let nested_dir = repo_path.join("nested-repo");
+    fs::create_dir_all(&nested_dir).expect("nested dir should be created");
+    git2::Repository::init(&nested_dir).expect("nested repo should be initialized");
+    fs::write(nested_dir.join("file.txt"), "inner\n").expect("nested file should be written");
+
+    let changes = changes::changed_files(&repo_path).expect("gix status should succeed");
+
+    assert!(
+        !changes
+            .iter()
+            .any(|change| change.path.as_path() == Path::new("nested-repo")),
+        "directory entries should be filtered out of changed files, but found 'nested-repo' in: {:?}",
+        changes.iter().map(|c| &c.path).collect::<Vec<_>>()
+    );
+}
+
 fn setup_git2_config(repo: &git2::Repository) {
     let mut config = repo.config().expect("config should be accessible");
     config

--- a/crates/arbor-gui/src/main.rs
+++ b/crates/arbor-gui/src/main.rs
@@ -6325,11 +6325,18 @@ fn read_head_file_bytes(worktree_path: &Path, file_path: &Path) -> Result<Vec<u8
         )
     })?;
 
+    if object.kind != gix::object::Kind::Blob {
+        return Ok(Vec::new());
+    }
+
     Ok(object.data.to_vec())
 }
 
 fn read_worktree_file_bytes(worktree_path: &Path, file_path: &Path) -> Result<Vec<u8>, String> {
     let absolute = worktree_path.join(file_path);
+    if absolute.is_dir() {
+        return Ok(Vec::new());
+    }
     match fs::read(&absolute) {
         Ok(bytes) => Ok(bytes),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),


### PR DESCRIPTION
## Problem
When a repository contains directory entries in its git status (e.g. submodules or nested git repositories), the `gix` crate (Rust git implementation) surfaces them as a single status entry instead of recursing into individual files. These directory paths flow into the diff pipeline, and clicking one in the Changes panel triggers `fs::read()` on a directory, which fails with:
```
failed to build diff: failed to read worktree file `/path/to/dir`: Is a directory (os error 21)
```

## Fix
- **Root cause:** Filter out directory entries in `changed_files()` (`arbor-core`) before they enter the pipeline — directories no longer appear in the Changes panel
- **Defense in depth:** Add `is_dir()` guard in `read_worktree_file_bytes` to prevent the os error 21 crash
- **Defense in depth:** Add `object.kind != Blob` guard in `read_head_file_bytes` to prevent passing raw git tree-object bytes to the text diff engine

## Test plan
- [x] `just format` passes
- [x] `just lint` passes (zero warnings)
- [x] `just test` passes
- [x] New integration test `excludes_directory_entries_from_changed_files` reproduces the bug (fails without fix, passes with fix)
- [x] Manual: open a repo with a nested git repo in changed files and verify clicking it no longer crashes