### PR TITLE
fix(httpd): import rand::RngExt for rand 0.10 fill API

### DIFF
--- a/crates/arbor-httpd/src/auth.rs
+++ b/crates/arbor-httpd/src/auth.rs
@@ -74,7 +74,7 @@ enum FailedAuthOutcome {
 impl AuthState {
     pub fn new(auth_token: Option<String>, allow_remote: bool) -> Self {
         let mut secret = [0u8; 32];
-        use rand::Rng;
+        use rand::RngExt;
         rand::rng().fill(&mut secret);
         Self {
             auth_token: auth_token

--- a/crates/arbor-httpd/src/types.rs
+++ b/crates/arbor-httpd/src/types.rs
@@ -323,7 +323,7 @@ pub(crate) fn ensure_auth_token(config: &mut DaemonConfig) {
         return;
     }
 
-    use rand::Rng;
+    use rand::RngExt;
     let mut bytes = [0u8; 16];
     rand::rng().fill(&mut bytes);
     let token: String = bytes.iter().map(|b| format!("{b:02x}")).collect();


### PR DESCRIPTION
rand 0.10 moved the fill() method from the Rng trait to a new RngExt trait. Update the two call sites in arbor-httpd to import RngExt so the release build (--locked) compiles cleanly.